### PR TITLE
Fixes #3

### DIFF
--- a/01_html-css/product-cards-with-hover/index.html
+++ b/01_html-css/product-cards-with-hover/index.html
@@ -19,42 +19,42 @@
             <div class="content__container">
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
                 <article class="product__card">
                     <h2 class="product__title">Producttitle</h2>
-                    <img class="product__img" src="/01_html-css/product-cards-with-hover/lib/product.jpg" alt="Plastic cup – product photo">
+                    <img class="product__img" src="./lib/product.jpg" alt="Plastic cup – product photo">
                     <p class="product__description">Lorem ipsum dolor sit amet, consetetur sadipscing elitr.</p>
                 </article>
             </div>


### PR DESCRIPTION
## 🇬🇧 English
The product image does not load correctly on GitHub Pages due to the leading slash (`/`) in the image path. This causes the browser to search from the domain root, which breaks relative asset paths.

### Proposed Fix:
Change all image paths to `./lib/...` to ensure relative resolution.

---

## 🇩🇪 Deutsch
Das Produktbild wird auf GitHub Pages nicht korrekt geladen, da der Pfad mit einem Schrägstrich (`/`) beginnt. Dadurch sucht der Browser im Domain-Root, was relative Pfade zerstört.

### Vorgeschlagene Lösung:
Alle Bildpfade zu `./lib/...` ändern, damit sie relativ zur Projektstruktur aufgelöst werden.

---

## 🇵🇱 Polski
Obrazek produktu nie ładuje się poprawnie na GitHub Pages z powodu ukośnika początkowego (`/`) w ścieżce. Przeglądarka szuka wtedy od root domeny, co psuje ścieżki względne.

### Proponowana poprawka:
Zmień wszystkie ścieżki obrazów na `./lib/...` aby zapewnić prawidłowe odniesienie względne.
